### PR TITLE
Built-in widget support

### DIFF
--- a/Songify Slim/Songify Slim.csproj
+++ b/Songify Slim/Songify Slim.csproj
@@ -541,6 +541,7 @@
       <DependentUpon>UC_PlaylistItem.xaml</DependentUpon>
     </Compile>
     <Compile Include="Util\BooleanToVisibilityConverter.cs" />
+    <Compile Include="Util\General\WebModuleServer.cs" />
     <Compile Include="Util\Songify\ApiClient.cs" />
     <Compile Include="Views\AboutWindow.xaml.cs">
       <DependentUpon>AboutWindow.xaml</DependentUpon>

--- a/Songify Slim/Util/General/WebModuleServer.cs
+++ b/Songify Slim/Util/General/WebModuleServer.cs
@@ -1,0 +1,115 @@
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Reflection;
+using System.Text;
+using System.Web;
+
+namespace Songify_Slim.Util.General
+{
+    public class WebModuleServer
+    {
+        private static readonly IDictionary<string, string> _mimeMappings =
+            new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
+            {
+                {".apng", "image/apng"},
+                {".avif", "image/avif"},
+                {".avifs", "image/avif-sequence"},
+                {".bmp", "image/bmp"},
+                {".css", "text/css" },
+                {".eot", "application/vnd.ms-fontobject"},
+                {".gif", "image/gif"},
+                {".html", "text/html" },
+                {".jpeg", "image/jpeg" },
+                {".jpg", "image/jpeg" },
+                {".js", "text/javascript" },
+                {".json", "application/json" },
+                {".otf", "application/font-sfnt"},
+                {".png", "image/png" },
+                {".svg", "image/svg+xml" },
+                {".ttf", "application/font-sfnt"},
+                {".webm", "image/webm" },
+                {".woff", "application/font-woff"},
+                {".woff2", "application/font-woff2"},
+            };
+
+        public static bool ProcessModule(HttpListenerContext context)
+        {
+            bool hasProcessed = false;
+            if (context.Request.Url.Segments.Length > 1)
+            {
+                switch (context.Request.Url.Segments[1])
+                {
+                    case "widget":
+                    case "Widget":
+                    case "widget/":
+                    case "Widget/":
+                        hasProcessed = ProcessWidget(context);
+                        break;
+                }
+            }
+
+            return hasProcessed;
+        }
+
+        private static bool ProcessWidget(HttpListenerContext context)
+        {
+            string[] fileSegments = context.Request.Url.Segments;
+            string path = Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location);
+            path += "/Widget/";
+
+            if (fileSegments.Length > 2)
+            {
+                for (int i = 2; i < fileSegments.Length; i++)
+                {
+                    path += fileSegments[i];
+                }
+            }
+            else
+            {
+                path += "index.html";
+            }
+
+            if (!File.Exists(path)) return false;
+
+            string mimeType = GetMime(path);
+            byte[] responseBytes = File.ReadAllBytes(path);
+
+            if (mimeType == "text/html")
+            {
+                string responseString = Encoding.UTF8.GetString(responseBytes, 0, responseBytes.Length);
+                responseString = responseString.Replace("<!-- settings -->", $"<script>const apiUrl = \"http://localhost:{context.Request.Url.Port}\";</script>");
+                responseBytes = Encoding.UTF8.GetBytes(responseString);
+            }
+
+            HttpListenerResponse response = context.Response;
+            response.ContentLength64 = responseBytes.Length;
+            response.Headers.Add("Access-Control-Allow-Origin", "*");
+            response.Headers.Add("Access-Control-Allow-Methods", "GET");
+            response.ContentType = mimeType;
+            if (mimeType.StartsWith("text/"))
+            {
+                response.ContentType += "; charset=utf-8";
+                response.ContentEncoding = Encoding.UTF8;
+            }
+
+            using (Stream output = response.OutputStream)
+            {
+                output.Write(responseBytes, 0, responseBytes.Length);
+            }
+
+            return true;
+        }
+
+        private static string GetMime(string path)
+        {
+            string mimeType = MimeMapping.GetMimeMapping(path);
+
+            string extension = Path.GetExtension(path);
+
+            return _mimeMappings.TryGetValue(extension, out string result) ? result : mimeType;
+        }
+    }
+}

--- a/Songify Slim/Util/General/WebModuleServer.cs
+++ b/Songify Slim/Util/General/WebModuleServer.cs
@@ -89,7 +89,7 @@ namespace Songify_Slim.Util.General
             response.Headers.Add("Access-Control-Allow-Origin", "*");
             response.Headers.Add("Access-Control-Allow-Methods", "GET");
             response.ContentType = mimeType;
-            if (mimeType.StartsWith("text/"))
+            if (mimeType == "text/html")
             {
                 response.ContentType += "; charset=utf-8";
                 response.ContentEncoding = Encoding.UTF8;

--- a/Songify Slim/Util/General/WebServer.cs
+++ b/Songify Slim/Util/General/WebServer.cs
@@ -5,8 +5,10 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using System.Web;
 using System.Windows;
 using System.Windows.Media;
 
@@ -84,7 +86,7 @@ namespace Songify_Slim.Util.General
 
         private void ProcessRequest(HttpListenerContext context)
         {
-            if (string.IsNullOrWhiteSpace(GlobalObjects.ApiResponse))
+            if (WebModuleServer.ProcessModule(context) || string.IsNullOrWhiteSpace(GlobalObjects.ApiResponse))
                 return;
             // Convert the response string to a byte array.
             byte[] responseBytes = Encoding.UTF8.GetBytes(GlobalObjects.ApiResponse);


### PR DESCRIPTION
While the web widget might be useful, there are a few drawbacks. For example, there aren't a lot of customization options. To counter that, one could build their own widget using their own web server and connecting to Songify's web server, which neatly serves most of the data as JSON. However, this requires someone to run a separate web server on their own computer.

This pull request adds an additional endpoint from where you can serve your own web server. `/Widget` allows you to serve a webpage that's stored in a separate `Widget` folder. What you can serve is limited, you can only serve certain file types, but these file types are enough.

To get this to work:

* In the application's folder, create a folder called `/Widget`;
* Add your `index.html` and any other file you want to include;
* Enable the web server;
* Add a Browser Source in your OBS and link to `localhost:<port>/Widget`.

This is primarily for advanced users, though with minimal instructions, widgets could be shared with everyone. It also allows for multiple widgets. There might not be a lot of use cases for this, but for those who want to personalize their own widget, this makes it possible.