### PR TITLE
Fix Artist / Title splitting when they contain dashes

### DIFF
--- a/Songify Slim/Util/Songify/SongFetcher.cs
+++ b/Songify Slim/Util/Songify/SongFetcher.cs
@@ -160,10 +160,12 @@ namespace Songify_Slim.Util.Songify
                                 title = "";
                                 extra = "";
                             }
-                            if (wintitle.Contains(" - "))
-                            {
-                                artist = wintitle.Split(Convert.ToChar("-"))[0].Trim();
-                                title = wintitle.Split(Convert.ToChar("-"))[1].Trim();
+                            int dashIndex = wintitle.IndexOf(" - ");
+                            if (dashIndex != -1)
+                            {   
+                                artist = wintitle.Substring(0, dashIndex).Trim();
+                                dashIndex += 3;
+                                title = wintitle.Substring(dashIndex, wintitle.Length - dashIndex).Trim();
                             }
                             trackinfo = new TrackInfo { Artists = artist, Title = title };
                             break;


### PR DESCRIPTION
It is entirely possible for a Song or Artist to contain a dash, in those cases the current implementation would either pick part of the artist as the title, or cut off part of the title if it contains a dash.

This change tries to improve upon that by splitting the title in two parts based off wherever the first " - " occurence is.