### PR TITLE
fix(windows-playback,queue,pear): improve cover sync and unsupported-player handling

### DIFF
--- a/Songify Slim/Util/General/GlobalObjects.cs
+++ b/Songify Slim/Util/General/GlobalObjects.cs
@@ -430,9 +430,6 @@ namespace Songify_Slim.Util.General
 
                     break;
 
-                case Enums.PlayerType.FooBar2000:
-                case Enums.PlayerType.Vlc:
-                case Enums.PlayerType.BrowserCompanion:
                 case Enums.PlayerType.Pear:
                     List<Song> pearQueue = await PearApi.GetQueueAsync();
                     PearResponse pearResponse = await PearApi.GetNowPlayingAsync();
@@ -499,8 +496,18 @@ namespace Songify_Slim.Util.General
                     break;
 
                 case Enums.PlayerType.WindowsPlayback:
+                case Enums.PlayerType.FooBar2000:
+                case Enums.PlayerType.Vlc:
+                case Enums.PlayerType.BrowserCompanion:
+                case Enums.PlayerType.Qobuz:
+                    Logger.Warning(LogSource.Core,
+                        $"QueueUpdateQueueWindow unsupported player (explicit): {Settings.Player}");
+                    return;
+
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    Logger.Warning(LogSource.Core,
+                        $"QueueUpdateQueueWindow unknown player enum value: {Settings.Player}");
+                    return;
             }
         }
 

--- a/Songify Slim/Util/General/IOManager.cs
+++ b/Songify Slim/Util/General/IOManager.cs
@@ -188,6 +188,7 @@ namespace Songify_Slim.Util.General
         public static async Task DownloadCover(string cover, string coverPath)
         {
             string coverTemp = $"{GlobalObjects.RootDirectory}/tmp_{Path.GetFileName(coverPath)}";
+            Logger.Debug(LogSource.Core, $"[IOManager.DownloadCover] Started with cover: {cover?.Substring(0, Math.Min(80, cover?.Length ?? 0))}... => {coverPath}");
 
             try
             {
@@ -269,6 +270,7 @@ namespace Songify_Slim.Util.General
                         }
 
                         File.Move(coverTemp, coverPath);
+                        Logger.Debug(LogSource.Core, $"[IOManager.DownloadCover] Cover file written successfully to {coverPath}");
                     }
                     catch (Exception ex)
                     {
@@ -283,6 +285,7 @@ namespace Songify_Slim.Util.General
                 }
 
                 // Update the image in the UI
+                Logger.Debug(LogSource.Core, $"[IOManager.DownloadCover] Calling SetCoverImage with path: {coverPath}");
                 Application.Current.Dispatcher.Invoke(() =>
                 {
                     if (Application.Current.MainWindow is MainWindow main)

--- a/Songify Slim/Util/General/ThumbnailConverter.cs
+++ b/Songify Slim/Util/General/ThumbnailConverter.cs
@@ -23,8 +23,10 @@ public static class ThumbnailConverter
         byte[] bytes;
         using (DataReader reader = new(stream.GetInputStreamAt(0)))
         {
-            bytes = new byte[stream.Size];
-            await reader.LoadAsync((uint)stream.Size);
+            int streamSize = checked((int)stream.Size);
+            uint streamSizeUInt32 = checked((uint)streamSize);
+            bytes = new byte[streamSize];
+            await reader.LoadAsync(streamSizeUInt32);
             reader.ReadBytes(bytes);
         }
 

--- a/Songify Slim/Util/Songify/SongFetcher.cs
+++ b/Songify Slim/Util/Songify/SongFetcher.cs
@@ -731,11 +731,13 @@ namespace Songify_Slim.Util.Songify
             if (thumbRef == null) return null;
 
             using IRandomAccessStreamWithContentType stream = await thumbRef.OpenReadAsync();
-            byte[] bytes = new byte[stream.Size];
-            _windowsPlaybackThumbnailBytesTotal += (long)stream.Size;
+            int streamSize = checked((int)stream.Size);
+            uint streamSizeUInt32 = checked((uint)streamSize);
+            byte[] bytes = new byte[streamSize];
+            _windowsPlaybackThumbnailBytesTotal += streamSize;
             using (DataReader reader = new(stream))
             {
-                await reader.LoadAsync((uint)stream.Size);
+                await reader.LoadAsync(streamSizeUInt32);
                 reader.ReadBytes(bytes);
             }
 

--- a/Songify Slim/Util/Songify/SongFetcher.cs
+++ b/Songify Slim/Util/Songify/SongFetcher.cs
@@ -74,6 +74,10 @@ namespace Songify_Slim.Util.Songify
         private static Tuple<bool, string> _canvasResponse;
         private static readonly Regex DriveLetterRegex = new(@"^[A-Z]:", RegexOptions.IgnoreCase);
         private PlaylistInfo playbackPlaylist = null;
+        
+            
+            
+            
 
         private readonly SemaphoreSlim _pearWsProcessLock = new(1, 1);
 
@@ -87,6 +91,16 @@ namespace Songify_Slim.Util.Songify
         // Pear/YT Music quirk: now-playing VideoId can differ from the queued item's Id.
         // Track the Pear queue's current item id so we can correlate requests reliably.
         private string _lastPearQueueCurrentId;
+
+        // Windows Playback metrics for performance instrumentation (PR 1 baseline)
+        private int _windowsPlaybackHeavyPathCount = 0;
+        private int _windowsPlaybackComRetryCount = 0;
+        private long _windowsPlaybackThumbnailBytesTotal = 0L;
+        private Stopwatch _windowsPlaybackLastMetricsReset = Stopwatch.StartNew();
+        private const int MetricsReportIntervalMs = 60000; // Report every 60 seconds
+
+        // Signature of the last thumbnail used, for change detection on track transitions.
+        private string _lastWindowsPlaybackThumbnailSig = null;
 
         /// <summary>
         ///     A method to fetch the song that's currently playing on Spotify.
@@ -712,12 +726,13 @@ namespace Songify_Slim.Util.Songify
             return mgr.GetCurrentSession();
         }
 
-        public static async Task<string> ThumbnailToDataUrlAsync(IRandomAccessStreamReference thumbRef)
+        public async Task<string> ThumbnailToDataUrlAsync(IRandomAccessStreamReference thumbRef)
         {
             if (thumbRef == null) return null;
 
             using IRandomAccessStreamWithContentType stream = await thumbRef.OpenReadAsync();
             byte[] bytes = new byte[stream.Size];
+            _windowsPlaybackThumbnailBytesTotal += (long)stream.Size;
             using (DataReader reader = new(stream))
             {
                 await reader.LoadAsync((uint)stream.Size);
@@ -730,6 +745,21 @@ namespace Songify_Slim.Util.Songify
             return $"data:image/png;base64,{base64}";
         }
 
+        /// <summary>
+        /// Quick signature for a thumbnail data URL used to detect when WinRT has updated
+        /// the thumbnail to match a new track. Uses first 128 chars of base64 data + total length.
+        /// </summary>
+        private static string ThumbnailSignature(string dataUrl)
+        {
+            if (dataUrl == null) return null;
+            // Skip the "data:image/png;base64," prefix (22 chars) for the content sample
+            int prefixLen = dataUrl.IndexOf(',') + 1;
+            string sample = prefixLen > 0 && dataUrl.Length > prefixLen
+                ? dataUrl.Substring(prefixLen, Math.Min(128, dataUrl.Length - prefixLen))
+                : dataUrl.Substring(0, Math.Min(128, dataUrl.Length));
+            return $"{dataUrl.Length}:{sample}";
+        }
+
         private async Task FetchWindowsApiCoreAsync(bool retried)
         {
             try
@@ -740,6 +770,7 @@ namespace Songify_Slim.Util.Songify
                 GlobalSystemMediaTransportControlsSession session = PickWindowsMediaSession(mgr, targetAumid);
                 if (session == null) { Console.WriteLine("No active media session."); return; }
 
+                _windowsPlaybackHeavyPathCount++;
                 GlobalSystemMediaTransportControlsSessionMediaProperties props = await session.TryGetMediaPropertiesAsync();
                 string title = props?.Title ?? "";
                 string artistFlat = props?.Artist ?? "";
@@ -748,7 +779,15 @@ namespace Songify_Slim.Util.Songify
                 int trackNo = props?.TrackNumber ?? 0;
                 string[] genres = props?.Genres?.ToArray() ?? [];
 
-                string thumbPath = await SaveThumbnailToTempAsync(props?.Thumbnail);
+                // Log fetch cycle metrics periodically
+                if (_windowsPlaybackLastMetricsReset.ElapsedMilliseconds > MetricsReportIntervalMs)
+                {
+                    Logger.Debug(LogSource.Core, $"Windows Playback fetch metrics: HeavyPathCount={_windowsPlaybackHeavyPathCount}, ComRetries={_windowsPlaybackComRetryCount}, ThumbnailBytesTotal={_windowsPlaybackThumbnailBytesTotal}");
+                    _windowsPlaybackHeavyPathCount = 0;
+                    _windowsPlaybackComRetryCount = 0;
+                    _windowsPlaybackThumbnailBytesTotal = 0L;
+                    _windowsPlaybackLastMetricsReset.Restart();
+                }
 
                 GlobalSystemMediaTransportControlsSessionPlaybackInfo playback = session.GetPlaybackInfo();
                 GlobalSystemMediaTransportControlsSessionTimelineProperties timeline = session.GetTimelineProperties();
@@ -770,12 +809,50 @@ namespace Songify_Slim.Util.Songify
 
                 List<SimpleArtist> fullArtists = SplitArtists(artistFlat);
 
+                // Detect track change by title/artist BEFORE reading thumbnail.
+                // WinRT often updates title/artist one tick ahead of the thumbnail stream,
+                // so we delay slightly and re-read props to get the correct cover art.
+                string candidateSongId = GenerateId(artistFlat, title);
+                bool isTrackChange = GlobalObjects.CurrentSong == null ||
+                    (GlobalObjects.CurrentSong.SongId != candidateSongId && candidateSongId != null) ||
+                    (candidateSongId == null && !string.IsNullOrEmpty(title));
+
+                string thumbUrl = null;
+                if (isTrackChange)
+                {
+                    // WinRT often updates title/artist before the thumbnail stream.
+                    // Poll until the thumbnail signature changes from the previous track (max ~1s).
+                    const int maxRetries = 5;
+                    const int retryDelayMs = 200;
+                    for (int attempt = 0; attempt <= maxRetries; attempt++)
+                    {
+                        if (attempt > 0)
+                        {
+                            await Task.Delay(retryDelayMs);
+                            props = await session.TryGetMediaPropertiesAsync();
+                        }
+                        thumbUrl = await ThumbnailToDataUrlAsync(props?.Thumbnail);
+                        string sig = ThumbnailSignature(thumbUrl);
+                        if (sig != _lastWindowsPlaybackThumbnailSig || attempt == maxRetries)
+                        {
+                            Logger.Debug(LogSource.Core, $"[WindowsPlayback] Track changed: \"{title}\" by {artistFlat} | Thumbnail: {(thumbUrl != null ? $"DataURL ({thumbUrl.Length} bytes)" : "null")} (attempt {attempt})");
+                            _lastWindowsPlaybackThumbnailSig = sig;
+                            break;
+                        }
+                        Logger.Debug(LogSource.Core, $"[WindowsPlayback] Thumbnail unchanged on attempt {attempt}, retrying...");
+                    }
+                }
+
                 TrackInfo tr = new()
                 {
                     Artists = artistFlat,
                     Title = title,
-                    Albums = [new Image { Url = await ThumbnailToDataUrlAsync(props?.Thumbnail) }],
-                    SongId = GenerateId(artistFlat, title),
+                    Albums = thumbUrl != null
+                        ? [new Image { Url = thumbUrl }]
+                        : (!isTrackChange 
+                            ? (GlobalObjects.CurrentSong?.Albums ?? [])
+                            : []),
+                    SongId = candidateSongId,
                     DurationMs = progress,
                     IsPlaying = isPlaying,
                     Url = null,
@@ -787,10 +864,7 @@ namespace Songify_Slim.Util.Songify
                 };
 
                 await UpdateWebServerResponse(tr);
-                tr.Albums = [new Image() { Url = thumbPath }];
-                if (GlobalObjects.CurrentSong == null ||
-                    (GlobalObjects.CurrentSong.SongId != tr.SongId && tr.SongId != null) ||
-                    (tr.SongId == null && !string.IsNullOrEmpty(tr.Title)))
+                if (isTrackChange)
                 {
                     GlobalObjects.CurrentSong = tr;
                     await WriteSongInfo(tr);
@@ -798,6 +872,7 @@ namespace Songify_Slim.Util.Songify
             }
             catch (COMException ex) when ((uint)ex.HResult == 0x80010108)
             {
+                _windowsPlaybackComRetryCount++;
                 if (!retried)
                 {
                     await FetchWindowsApiCoreAsync(retried: true);
@@ -834,29 +909,6 @@ namespace Songify_Slim.Util.Songify
                 >= int.MaxValue => int.MaxValue,
                 _ => (int)Math.Round(ms)
             };
-        }
-
-        /// <summary>
-        /// Save WinRT thumbnail stream to a temp PNG/JPEG file and return its absolute path (or null).
-        /// Must be called on the same STA thread where the WinRT object was obtained.
-        /// </summary>
-        private static async Task<string> SaveThumbnailToTempAsync(IRandomAccessStreamReference thumbRef)
-        {
-            if (thumbRef == null) return null;
-
-            string dir = Path.Combine(Path.GetTempPath(), "SongifySlim", "covers");
-            Directory.CreateDirectory(dir);
-            string path = Path.Combine(dir, $"cover_{Guid.NewGuid():N}.png");
-
-            using IRandomAccessStreamWithContentType stream = await thumbRef.OpenReadAsync();
-            byte[] bytes = new byte[stream.Size];
-            using (DataReader reader = new(stream))
-            {
-                await reader.LoadAsync((uint)stream.Size);
-                reader.ReadBytes(bytes);
-            }
-            File.WriteAllBytes(path, bytes);
-            return path;
         }
 
         /// <summary>
@@ -1239,11 +1291,13 @@ namespace Songify_Slim.Util.Songify
             // Check if there is a canvas available for the song id using https://api.songify.rocks/v2/canvas/{ID}, if there is us that instead
             if (Settings.DownloadCanvas && _canvasResponse is { Item1: true })
             {
+                Logger.Debug(LogSource.Core, $"[WriteSongInfo] Downloading cover (canvas mode): {albumUrl?.Substring(0, Math.Min(100, albumUrl?.Length ?? 0))}...");
                 IoManager.DownloadCanvas(_canvasResponse.Item2, Path.Combine(GlobalObjects.RootDirectory, "canvas.mp4"));
                 await IoManager.DownloadCover(albumUrl, Path.Combine(GlobalObjects.RootDirectory, "cover.png"));
             }
             else if (Settings.DownloadCover)
             {
+                Logger.Debug(LogSource.Core, $"[WriteSongInfo] Downloading cover: {albumUrl?.Substring(0, Math.Min(100, albumUrl?.Length ?? 0))}...");
                 await IoManager.DownloadCover(albumUrl, Path.Combine(GlobalObjects.RootDirectory, "cover.png"));
             }
 
@@ -1617,9 +1671,18 @@ namespace Songify_Slim.Util.Songify
 
                 await UpdateWebServerResponse(t).ConfigureAwait(false);
 
-                // If same song, nothing more (web payload already refreshed above).
-                if (GlobalObjects.CurrentSong != null && GlobalObjects.CurrentSong.SongId == canonicalId)
+                bool isSameSongId = GlobalObjects.CurrentSong != null &&
+                                    GlobalObjects.CurrentSong.SongId == canonicalId;
+
+                // On the first Pear bootstrap sync after connect/player switch, we still need to
+                // run the full write path so MainWindow now-playing text gets refreshed even if
+                // the track id matches the previous in-memory song.
+                if (isSameSongId && _pearColdHttpSynced)
+                {
+                    GlobalObjects.CurrentSong = t;
+                    UpdatePearNowPlayingPreviewOnly(t);
                     return;
+                }
 
                 if (GlobalObjects.CurrentSkipPoll != null && GlobalObjects.CurrentSkipPoll.IsActive)
                 {
@@ -1634,6 +1697,43 @@ namespace Songify_Slim.Util.Songify
             {
                 _pearStateLock.Release();
             }
+        }
+
+        /// <summary>
+        /// Refresh MainWindow now-playing text without executing full WriteSongInfo side effects
+        /// (history upload/chat announce/files). Used for Pear same-song state updates.
+        /// </summary>
+        private static void UpdatePearNowPlayingPreviewOnly(TrackInfo track)
+        {
+            if (track == null)
+                return;
+
+            string singleArtist = track.FullArtists?.FirstOrDefault()?.Name ?? track.Artists ?? "";
+            string output = Settings.OutputString;
+
+            int start = output.IndexOf("{{", StringComparison.Ordinal);
+            int end = output.LastIndexOf("}}", StringComparison.Ordinal) + 2;
+            if (start >= 0 && end > start)
+                output = output.Remove(start, end - start);
+
+            output = output.Format(
+                single_artist => singleArtist,
+                artist => track.Artists ?? "",
+                title => track.Title ?? "",
+                extra => "",
+                uri => track.SongId ?? "",
+                url => track.Url ?? ""
+            ).Format();
+
+            output = CleanFormatString(output);
+            if (string.IsNullOrWhiteSpace(output))
+                return;
+
+            Application.Current?.Dispatcher.Invoke(() =>
+            {
+                if (Application.Current.MainWindow is MainWindow main)
+                    main.SetTextPreview(output.Trim().Replace(@"\n", " - ").Replace("  ", " "));
+            });
         }
 
         private async Task PatchPearPlaybackFromWebSocketAsync(double elapsedSeconds, bool? isPlaying)

--- a/Songify Slim/Util/Spotify/SpotifyApiHandler.cs
+++ b/Songify Slim/Util/Spotify/SpotifyApiHandler.cs
@@ -11,10 +11,13 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net.NetworkInformation;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Sockets;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -197,15 +200,19 @@ namespace Songify_Slim.Util.Spotify
 
                 try
                 {
+                    EnsureExclusiveLoopbackPortAvailable(4002);
                     await _server.Start();
                 }
                 catch (Exception ex)
                 {
                     Logger.Log(LogLevel.Error, LogSource.Spotify,
                         "OAuth callback server could not start on port 4002.", ex);
+
+                    string ownerSummary = GetPortOwnerSummary(4002);
                     SpotifyUserNotifier.Notify(
                         "Spotify login server failed",
-                        "Songify could not listen on port 4002. Another program may be using it, or access was denied. Close other apps using that port or run Songify as administrator once to allow the firewall prompt.",
+                        "Songify could not listen on port 4002. Another program may be using it, or access was denied. " +
+                        ownerSummary + " Close other apps using that port or run Songify as administrator once to allow the firewall prompt.",
                         "spotify:pkce:port",
                         TimeSpan.FromMinutes(3));
                     throw;
@@ -252,6 +259,234 @@ namespace Songify_Slim.Util.Spotify
                 CancelPkceLoginWatchdog();
                 throw;
             }
+        }
+
+        private static void EnsureExclusiveLoopbackPortAvailable(int port)
+        {
+            var existingListeners = IPGlobalProperties.GetIPGlobalProperties()
+                .GetActiveTcpListeners()
+                .Where(ep => ep.Port == port)
+                .ToList();
+
+            if (existingListeners.Count > 0)
+            {
+                string endpoints = string.Join(", ", existingListeners.Select(ep => ep.Address + ":" + ep.Port));
+                string owners = GetPortOwnerSummary(port);
+                throw new InvalidOperationException(
+                    $"Port {port} is already in use by active listener(s): {endpoints}. {owners}");
+            }
+
+            ProbeExclusiveBind(IPAddress.Loopback, port);
+
+            if (Socket.OSSupportsIPv6)
+            {
+                try
+                {
+                    ProbeExclusiveBind(IPAddress.IPv6Loopback, port);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    Logger.Log(LogLevel.Debug, LogSource.Spotify,
+                        $"IPv6 loopback probe failed for port {port}; continuing with IPv4-only OAuth callback.", ex);
+                }
+            }
+        }
+
+        private static void ProbeExclusiveBind(IPAddress address, int port)
+        {
+            TcpListener probe = null;
+
+            try
+            {
+                probe = new TcpListener(address, port)
+                {
+                    ExclusiveAddressUse = true
+                };
+
+                probe.Server.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, false);
+                probe.Start(1);
+            }
+            catch (SocketException ex)
+            {
+                string owners = GetPortOwnerSummary(port);
+                throw new InvalidOperationException(
+                    $"Port {port} cannot be reserved exclusively on {address}. {owners}", ex);
+            }
+            finally
+            {
+                try
+                {
+                    probe?.Stop();
+                }
+                catch
+                {
+                    // Best-effort cleanup for the probe socket.
+                }
+            }
+        }
+
+        private static string GetPortOwnerSummary(int port)
+        {
+            try
+            {
+                var owners = GetPortOwnersFromSystemTables(port);
+                if (owners.Count == 0)
+                    return "No owning process could be resolved.";
+
+                return "Likely owner(s): " + string.Join(", ", owners);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log(LogLevel.Debug, LogSource.Spotify, "Failed to resolve port owner information", ex);
+                return "Owning process could not be resolved.";
+            }
+        }
+
+        private static List<string> GetPortOwnersFromSystemTables(int port)
+        {
+            var ownerEntries = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (int pid in GetListenerPidsForPort(port))
+            {
+                string procName;
+                try
+                {
+                    procName = System.Diagnostics.Process.GetProcessById(pid).ProcessName;
+                }
+                catch
+                {
+                    procName = "unknown";
+                }
+
+                ownerEntries.Add($"{procName} (PID {pid})");
+            }
+
+            return ownerEntries.ToList();
+        }
+
+        private static IEnumerable<int> GetListenerPidsForPort(int port)
+        {
+            var pids = new HashSet<int>();
+
+            foreach (MibTcpRowOwnerPid row in GetTcpListenerRowsV4())
+            {
+                if (ParsePort(row.LocalPort) == port)
+                    pids.Add((int)row.OwningPid);
+            }
+
+            foreach (MibTcp6RowOwnerPid row in GetTcpListenerRowsV6())
+            {
+                if (ParsePort(row.LocalPort) == port)
+                    pids.Add((int)row.OwningPid);
+            }
+
+            return pids;
+        }
+
+        private static List<MibTcpRowOwnerPid> GetTcpListenerRowsV4()
+        {
+            return ReadTcpTable<MibTcpRowOwnerPid>(AddressFamilyInterNetwork);
+        }
+
+        private static List<MibTcp6RowOwnerPid> GetTcpListenerRowsV6()
+        {
+            return ReadTcpTable<MibTcp6RowOwnerPid>(AddressFamilyInterNetworkV6);
+        }
+
+        private static List<T> ReadTcpTable<T>(int addressFamily) where T : struct
+        {
+            int size = 0;
+            uint result = GetExtendedTcpTable(IntPtr.Zero, ref size, true, addressFamily,
+                TcpTableClass.TcpTableOwnerPidListener, 0);
+
+            if (result != 0 && result != ErrorInsufficientBuffer)
+                return [];
+
+            IntPtr tablePtr = IntPtr.Zero;
+            try
+            {
+                tablePtr = Marshal.AllocHGlobal(size);
+                result = GetExtendedTcpTable(tablePtr, ref size, true, addressFamily,
+                    TcpTableClass.TcpTableOwnerPidListener, 0);
+
+                if (result != 0)
+                    return [];
+
+                int rowCount = Marshal.ReadInt32(tablePtr);
+                IntPtr rowPtr = tablePtr + sizeof(int);
+                int rowSize = Marshal.SizeOf(typeof(T));
+
+                var rows = new List<T>(rowCount);
+                for (int i = 0; i < rowCount; i++)
+                {
+                    rows.Add((T)Marshal.PtrToStructure(rowPtr, typeof(T)));
+                    rowPtr += rowSize;
+                }
+
+                return rows;
+            }
+            finally
+            {
+                if (tablePtr != IntPtr.Zero)
+                    Marshal.FreeHGlobal(tablePtr);
+            }
+        }
+
+        private static int ParsePort(byte[] localPortBytes)
+        {
+            if (localPortBytes == null || localPortBytes.Length < 2)
+                return -1;
+
+            // MIB local port bytes are stored in network order.
+            return (localPortBytes[0] << 8) + localPortBytes[1];
+        }
+
+        private const int ErrorInsufficientBuffer = 122;
+        private const int AddressFamilyInterNetwork = 2;
+        private const int AddressFamilyInterNetworkV6 = 23;
+
+        [DllImport("iphlpapi.dll", SetLastError = true)]
+        private static extern uint GetExtendedTcpTable(
+            IntPtr pTcpTable,
+            ref int dwOutBufLen,
+            bool sort,
+            int ipVersion,
+            TcpTableClass tblClass,
+            uint reserved);
+
+        private enum TcpTableClass
+        {
+            TcpTableOwnerPidListener = 3
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct MibTcpRowOwnerPid
+        {
+            public uint State;
+            public uint LocalAddr;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
+            public byte[] LocalPort;
+            public uint RemoteAddr;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
+            public byte[] RemotePort;
+            public uint OwningPid;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct MibTcp6RowOwnerPid
+        {
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+            public byte[] LocalAddr;
+            public uint LocalScopeId;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
+            public byte[] LocalPort;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+            public byte[] RemoteAddr;
+            public uint RemoteScopeId;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
+            public byte[] RemotePort;
+            public uint State;
+            public uint OwningPid;
         }
 
         private static Task OnAuthError(object sender, string error, string receivedState)

--- a/Songify Slim/Util/Spotify/SpotifyApiHandler.cs
+++ b/Songify Slim/Util/Spotify/SpotifyApiHandler.cs
@@ -741,6 +741,10 @@ namespace Songify_Slim.Util.Spotify
                 Logger.Error(LogSource.Spotify, "Couldn't fetch song info");
                 Logger.Error(LogSource.Spotify, ApiCallMeter.FormatApiExceptionDetails(apiEx));
             }
+            catch (OperationCanceledException)
+            {
+                Logger.Error(LogSource.Spotify, "Couldn't fetch song info (spotify api timeout)");
+            }
             catch (Exception ex)
             {
                 Logger.Error(LogSource.Spotify, "Couldn't fetch song info (unexpected)");

--- a/Songify Slim/Views/MainWindow.xaml.cs
+++ b/Songify Slim/Views/MainWindow.xaml.cs
@@ -1762,6 +1762,7 @@ namespace Songify_Slim.Views
                 _timerFetcher.Enabled = false;
                 _timerFetcher.Elapsed -= OnTimedEvent;
                 CancellationTokenSource _sCts = new CancellationTokenSource();
+                Stopwatch fetchLoopStart = _selectedSource == PlayerType.WindowsPlayback ? Stopwatch.StartNew() : null;
 
                 try
                 {
@@ -1796,9 +1797,22 @@ namespace Songify_Slim.Views
                 {
                     _sCts.CancelAfter(3500);
                     await GetCurrentSongAsync();
+                    if (fetchLoopStart != null)
+                    {
+                        fetchLoopStart.Stop();
+                        if (fetchLoopStart.ElapsedMilliseconds > 100)
+                            Logger.Debug(LogSource.Core, $"Windows Playback fetch loop took {fetchLoopStart.ElapsedMilliseconds}ms");
+                    }
                 }
                 catch (TaskCanceledException ex)
                 {
+                    if (fetchLoopStart != null && fetchLoopStart.IsRunning)
+                    {
+                        fetchLoopStart.Stop();
+                        if (fetchLoopStart.ElapsedMilliseconds > 100)
+                            Logger.Debug(LogSource.Core, $"Windows Playback fetch loop canceled after {fetchLoopStart.ElapsedMilliseconds}ms");
+                    }
+
                     Logger.LogExc(ex);
                 }
                 finally
@@ -1946,6 +1960,7 @@ namespace Songify_Slim.Views
 
         public async void SetCoverImage(string coverPath)
         {
+            Logger.Debug(LogSource.Core, $"[MainWindow.SetCoverImage] Called with path: {coverPath}");
             const int numberOfRetries = 5;
             const int delayOnRetry = 1000;
 
@@ -1962,9 +1977,11 @@ namespace Songify_Slim.Views
                         image.UriSource = new Uri(coverPath);
                         image.EndInit();
                         ImgCover.Source = image;
+                        Logger.Debug(LogSource.Core, $"[MainWindow.SetCoverImage] Successfully loaded image from {coverPath}");
                     }
-                    catch (Exception)
+                    catch (Exception ex)
                     {
+                        Logger.Debug(LogSource.Core, $"[MainWindow.SetCoverImage] Attempt {i} failed: {ex.Message}, retrying...");
                         //                        await Task.Delay(1000);
                         continue;
                     }
@@ -1978,19 +1995,22 @@ namespace Songify_Slim.Views
                     {
                         ImgCover.Visibility = Visibility.Visible;
                         GrdCover.Visibility = Visibility.Visible;
+                        Logger.Debug(LogSource.Core, $"[MainWindow.SetCoverImage] Image visible for {Settings.Player}");
                     }
                     else
                     {
                         ImgCover.Visibility = Visibility.Collapsed;
                         GrdCover.Visibility = Visibility.Collapsed;
+                        Logger.Debug(LogSource.Core, $"[MainWindow.SetCoverImage] Image hidden (Player: {Settings.Player}, DownloadCover: {Settings.DownloadCover})");
                     }
 
                     CoverCanvas.Visibility = Visibility.Collapsed;
 
                     break;
                 }
-                catch (Exception) when (i <= numberOfRetries)
+                catch (Exception ex) when (i <= numberOfRetries)
                 {
+                    Logger.Debug(LogSource.Core, $"[MainWindow.SetCoverImage] Outer catch at attempt {i}: {ex.Message}");
                     Thread.Sleep(delayOnRetry);
                 }
             }

--- a/Songify Slim/Views/MainWindow.xaml.cs
+++ b/Songify Slim/Views/MainWindow.xaml.cs
@@ -1982,7 +1982,7 @@ namespace Songify_Slim.Views
                     catch (Exception ex)
                     {
                         Logger.Debug(LogSource.Core, $"[MainWindow.SetCoverImage] Attempt {i} failed: {ex.Message}, retrying...");
-                        //                        await Task.Delay(1000);
+                        await Task.Delay(delayOnRetry);
                         continue;
                     }
 
@@ -2011,7 +2011,7 @@ namespace Songify_Slim.Views
                 catch (Exception ex) when (i <= numberOfRetries)
                 {
                     Logger.Debug(LogSource.Core, $"[MainWindow.SetCoverImage] Outer catch at attempt {i}: {ex.Message}");
-                    Thread.Sleep(delayOnRetry);
+                    await Task.Delay(delayOnRetry);
                 }
             }
         }

--- a/Songify Slim/Views/Window_Queue.xaml.cs
+++ b/Songify Slim/Views/Window_Queue.xaml.cs
@@ -62,10 +62,16 @@ namespace Songify_Slim.Views
                     break;
 
                 case Enums.PlayerType.Pear:
+                    SetButtonContent(!GlobalObjects.CurrentSong.IsPlaying);
+                    break;
+
+                case Enums.PlayerType.Qobuz:
                     break;
 
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    Logger.Warning(LogSource.Core,
+                        $"WindowQueue.Timer_Tick hit unsupported player: {Settings.Player}");
+                    break;
             }
         }
 
@@ -153,7 +159,18 @@ namespace Songify_Slim.Views
                         break;
                     }
 
+                case Enums.PlayerType.WindowsPlayback:
+                case Enums.PlayerType.FooBar2000:
+                case Enums.PlayerType.Vlc:
+                case Enums.PlayerType.BrowserCompanion:
+                case Enums.PlayerType.Qobuz:
+                    Logger.Warning(LogSource.Core,
+                        $"WindowQueue.DgvButtonDelete_Click unsupported player (explicit): {Settings.Player}");
+                    return;
+
                 default:
+                    Logger.Warning(LogSource.Core,
+                        $"WindowQueue.DgvButtonDelete_Click unknown player enum value: {Settings.Player}");
                     return;
             }
 
@@ -261,7 +278,18 @@ namespace Songify_Slim.Views
                         break;
                     }
 
+                case Enums.PlayerType.WindowsPlayback:
+                case Enums.PlayerType.FooBar2000:
+                case Enums.PlayerType.Vlc:
+                case Enums.PlayerType.BrowserCompanion:
+                case Enums.PlayerType.Qobuz:
+                    Logger.Warning(LogSource.Core,
+                        $"WindowQueue.DgvButtonSkip_Click unsupported player (explicit): {Settings.Player}");
+                    return;
+
                 default:
+                    Logger.Warning(LogSource.Core,
+                        $"WindowQueue.DgvButtonSkip_Click unknown player enum value: {Settings.Player}");
                     return;
             }
 
@@ -467,10 +495,13 @@ namespace Songify_Slim.Views
                     case Enums.PlayerType.FooBar2000:
                     case Enums.PlayerType.Vlc:
                     case Enums.PlayerType.BrowserCompanion:
+                    case Enums.PlayerType.Qobuz:
                         break;
 
                     default:
-                        throw new ArgumentOutOfRangeException();
+                        Logger.Warning(LogSource.Core,
+                            $"WindowQueue.BtnBack_OnClick(quick) unsupported player: {Settings.Player}");
+                        break;
                 }
             }
             else
@@ -490,10 +521,13 @@ namespace Songify_Slim.Views
                     case Enums.PlayerType.FooBar2000:
                     case Enums.PlayerType.Vlc:
                     case Enums.PlayerType.BrowserCompanion:
+                    case Enums.PlayerType.Qobuz:
                         break;
 
                     default:
-                        throw new ArgumentOutOfRangeException();
+                        Logger.Warning(LogSource.Core,
+                            $"WindowQueue.BtnBack_OnClick(normal) unsupported player: {Settings.Player}");
+                        break;
                 }
                 // If not, restart the current track from the beginning
             }
@@ -518,10 +552,13 @@ namespace Songify_Slim.Views
                 case Enums.PlayerType.FooBar2000:
                 case Enums.PlayerType.Vlc:
                 case Enums.PlayerType.BrowserCompanion:
+                case Enums.PlayerType.Qobuz:
                     break;
 
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    Logger.Warning(LogSource.Core,
+                        $"WindowQueue.BtnNext_OnClick unsupported player: {Settings.Player}");
+                    break;
             }
         }
 
@@ -535,10 +572,6 @@ namespace Songify_Slim.Views
                         SetButtonContent(!isPlaying);
                         break;
                     }
-                case Enums.PlayerType.WindowsPlayback:
-                case Enums.PlayerType.FooBar2000:
-                case Enums.PlayerType.Vlc:
-                case Enums.PlayerType.BrowserCompanion:
                 case Enums.PlayerType.Pear:
                     {
                         PearResponse nowPlaying = await PearApi.GetNowPlayingAsync();
@@ -552,8 +585,18 @@ namespace Songify_Slim.Views
                         SetButtonContent(isPlaying);
                         break;
                     }
+                case Enums.PlayerType.WindowsPlayback:
+                case Enums.PlayerType.FooBar2000:
+                case Enums.PlayerType.Vlc:
+                case Enums.PlayerType.BrowserCompanion:
+                case Enums.PlayerType.Qobuz:
+                    {
+                        break;
+                    }
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    Logger.Warning(LogSource.Core,
+                        $"WindowQueue.BtnPlayPause_OnClick unsupported player: {Settings.Player}");
+                    break;
             }
         }
 

--- a/Songify Slim/Views/Window_Queue.xaml.cs
+++ b/Songify Slim/Views/Window_Queue.xaml.cs
@@ -165,12 +165,12 @@ namespace Songify_Slim.Views
                 case Enums.PlayerType.BrowserCompanion:
                 case Enums.PlayerType.Qobuz:
                     Logger.Warning(LogSource.Core,
-                        $"WindowQueue.DgvButtonDelete_Click unsupported player (explicit): {Settings.Player}");
+                        $"WindowQueue.DgvItemDelete_Click unsupported player (explicit): {Settings.Player}");
                     return;
 
                 default:
                     Logger.Warning(LogSource.Core,
-                        $"WindowQueue.DgvButtonDelete_Click unknown player enum value: {Settings.Player}");
+                        $"WindowQueue.DgvItemDelete_Click unknown player enum value: {Settings.Player}");
                     return;
             }
 


### PR DESCRIPTION
Improve Windows Playback cover refresh by tracking thumbnail signatures, retrying thumbnail reads on track change, and adding fetch-loop metrics for heavy-path, COM retries, and thumbnail payload size.

Refresh Pear now-playing preview on cold sync even when the song id is unchanged, without triggering full WriteSongInfo side effects.

Replace queue-window out-of-range throws with explicit unsupported-player warnings (including Qobuz), and add timeout-specific Spotify fetch logging plus extra cover download/render diagnostics.