### PR TITLE
fix(twitch,spotify,queue,logging): Improve Twitch startup reliability, Spotify device recovery, and Pear status/diagnostic UX

### DIFF
--- a/Songify Slim/Util/General/GlobalObjects.cs
+++ b/Songify Slim/Util/General/GlobalObjects.cs
@@ -278,7 +278,7 @@ namespace Songify_Slim.Util.General
                                 {
                                     try
                                     {
-                                        if (item.Trackid == CurrentSong.SongId)
+                                        if (CurrentSong != null && item.Trackid == CurrentSong.SongId)
                                         {
                                             return;
                                         }
@@ -333,9 +333,12 @@ namespace Songify_Slim.Util.General
                                     ? isInLikedSongs.TryGetValue(fullTrack.Id, out bool boolValue) && boolValue
                                     : LikedPlaylistTracks.Any(o => ((FullTrack)o.Track).Id == fullTrack.Id);
 
-                                RequestObject reqObj = ReqList.FirstOrDefault(o =>
-                                    o.Trackid == fullTrack.Id && !replacementTracker.ContainsKey(o.Trackid) &&
-                                    fullTrack.Id != CurrentSong.SongId);
+                                // Exclude the currently playing track from queue matching — guard CurrentSong null.
+                                bool isCurrentSong = CurrentSong != null && fullTrack.Id == CurrentSong.SongId;
+                                RequestObject reqObj = isCurrentSong
+                                    ? null
+                                    : ReqList.FirstOrDefault(o =>
+                                        o.Trackid == fullTrack.Id && !replacementTracker.ContainsKey(o.Trackid));
 
                                 RequestObject skipObj = SkipList.FirstOrDefault(o => o.Trackid == fullTrack.Id);
 

--- a/Songify Slim/Util/General/Logger.cs
+++ b/Songify Slim/Util/General/Logger.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Text.Json;
 using System.Windows;
 using System.Windows.Documents;
 using System.Windows.Media;
@@ -135,6 +136,22 @@ namespace Songify_Slim.Util.General
 
         public static void Error(LogSource source, string message, Exception? exception = null) =>
             Log(LogLevel.Error, source, message, exception);
+
+        /// <summary>
+        /// Logs a JSON parse exception with contextual payload preview centered around the parse error.
+        /// </summary>
+        public static void ErrorJsonParse(LogSource source, string message, string rawJson, JsonException exception,
+            int contextChars = 120)
+        {
+            if (exception == null)
+            {
+                Log(LogLevel.Error, source, message);
+                return;
+            }
+
+            string enriched = BuildJsonParseErrorMessage(message, rawJson, exception, contextChars);
+            Log(LogLevel.Error, source, enriched, exception);
+        }
 
         public static void Fatal(LogSource source, string message, Exception? exception = null) =>
             Log(LogLevel.Fatal, source, message, exception);
@@ -269,6 +286,75 @@ namespace Songify_Slim.Util.General
         private static Color GetForegroundColor(LogSource source)
         {
             return ColorMappings.First(o => o.Key == source).Value;
+        }
+
+        private static string BuildJsonParseErrorMessage(string message, string rawJson, JsonException exception,
+            int contextChars)
+        {
+            string path = string.IsNullOrWhiteSpace(exception.Path) ? "<unknown>" : exception.Path;
+            string line = exception.LineNumber?.ToString() ?? "<unknown>";
+            string bytePos = exception.BytePositionInLine?.ToString() ?? "<unknown>";
+            int payloadLength = rawJson?.Length ?? 0;
+
+            int? errorIndex = TryGetApproximateJsonErrorIndex(rawJson, exception);
+            string preview = BuildJsonPreview(rawJson, errorIndex, contextChars);
+
+            return $"{message} Path={path}, Line={line}, Byte={bytePos}, PayloadLength={payloadLength}, Preview={preview}";
+        }
+
+        private static int? TryGetApproximateJsonErrorIndex(string rawJson, JsonException exception)
+        {
+            if (string.IsNullOrEmpty(rawJson) || exception == null)
+                return null;
+
+            long? lineNumber = exception.LineNumber;
+            long? bytePositionInLine = exception.BytePositionInLine;
+            if (!lineNumber.HasValue || !bytePositionInLine.HasValue)
+                return null;
+
+            if (lineNumber.Value < 0 || bytePositionInLine.Value < 0)
+                return null;
+
+            int lineStart = 0;
+            for (long i = 0; i < lineNumber.Value; i++)
+            {
+                int newlineIdx = rawJson.IndexOf('\n', lineStart);
+                if (newlineIdx < 0)
+                    return null;
+
+                lineStart = newlineIdx + 1;
+            }
+
+            long absoluteIndex = lineStart + bytePositionInLine.Value;
+            if (absoluteIndex < 0)
+                return null;
+
+            if (absoluteIndex >= rawJson.Length)
+                return rawJson.Length == 0 ? 0 : rawJson.Length - 1;
+
+            return (int)absoluteIndex;
+        }
+
+        private static string BuildJsonPreview(string rawJson, int? errorIndex, int contextChars)
+        {
+            if (string.IsNullOrWhiteSpace(rawJson))
+                return "<empty>";
+
+            int length = rawJson.Length;
+            int safeContext = Math.Max(0, contextChars);
+            int center = errorIndex.HasValue
+                ? Math.Max(0, Math.Min(length - 1, errorIndex.Value))
+                : Math.Min(length - 1, safeContext);
+
+            int start = Math.Max(0, center - safeContext);
+            int endExclusive = Math.Min(length, center + safeContext);
+            if (endExclusive <= start)
+                return "<empty>";
+
+            string snippet = rawJson.Substring(start, endExclusive - start);
+            string prefix = start > 0 ? "..." : "";
+            string suffix = endExclusive < length ? "..." : "";
+            return $"{prefix}{snippet}{suffix} (start={start})";
         }
 
         // ------------- HELPER: infer source from message for old API -------------

--- a/Songify Slim/Util/General/Logger.cs
+++ b/Songify Slim/Util/General/Logger.cs
@@ -118,13 +118,13 @@ namespace Songify_Slim.Util.General
 
         // ------------- NEW, MORE STRUCTURED API -------------
 
-        public static void Trace(LogSource source, string message) =>
-            Log(LogLevel.Trace, source, message);
+        public static void Trace(LogSource source, string message, Exception? exception = null) =>
+            Log(LogLevel.Trace, source, message, exception);
 
-        public static void Debug(LogSource source, string message)
+        public static void Debug(LogSource source, string message, Exception? exception = null)
         {
             if (Settings.DebugLogging)
-                Log(LogLevel.Debug, source, message);
+                Log(LogLevel.Debug, source, message, exception);
         }
 
         public static void Info(LogSource source, string message) =>

--- a/Songify Slim/Util/Songify/SongFetcher.cs
+++ b/Songify Slim/Util/Songify/SongFetcher.cs
@@ -1813,7 +1813,7 @@ namespace Songify_Slim.Util.Songify
             }
             catch (System.Text.Json.JsonException ex)
             {
-                Logger.Error(LogSource.Pear, "Pear WebSocket JSON parse failed.", ex);
+                Logger.ErrorJsonParse(LogSource.Pear, "Pear WebSocket JSON parse failed.", msg, ex);
             }
             catch (Exception ex)
             {

--- a/Songify Slim/Util/Songify/Twitch/TwitchHandler.cs
+++ b/Songify Slim/Util/Songify/Twitch/TwitchHandler.cs
@@ -612,8 +612,40 @@ public static class TwitchHandler
         });
     }
 
+    /// <summary>
+    /// Logs diagnostic information about Twitch account initialization state.
+    /// Used for troubleshooting timing-dependent initialization issues.
+    /// </summary>
+    private static void LogTwitchAccountDiagnostics(string context)
+    {
+        try
+        {
+            string twAccEmpty = string.IsNullOrEmpty(Settings.TwAcc) ? "TRUE" : $"false ('{Settings.TwAcc}')";
+            string mainUserPresent = Settings.TwitchUser != null ? $"TRUE ('{Settings.TwitchUser.Login}')" : "FALSE";
+            string botUserPresent = Settings.TwitchBotUser != null ? $"TRUE ('{Settings.TwitchBotUser.Login}')" : "FALSE";
+            string mainTokenPresent = !string.IsNullOrWhiteSpace(Settings.TwitchAccessToken) ? $"TRUE ({Settings.TwitchAccessToken.Length} chars)" : "FALSE";
+            string botTokenPresent = !string.IsNullOrWhiteSpace(Settings.TwitchBotToken) ? $"TRUE ({Settings.TwitchBotToken.Length} chars)" : "FALSE";
+
+            Logger.Debug(LogSource.Twitch, 
+                $"[{context}] Twitch Account Diagnostics: " +
+                $"TwAccEmpty={twAccEmpty}, " +
+                $"MainUserPresent={mainUserPresent}, " +
+                $"BotUserPresent={botUserPresent}, " +
+                $"MainTokenPresent={mainTokenPresent}, " +
+                $"BotTokenPresent={botTokenPresent}");
+        }
+        catch (Exception ex)
+        {
+            Logger.Warning(LogSource.Twitch, $"[{context}] Failed to log diagnostics: {ex.Message}");
+        }
+    }
+
     public static bool RefreshSelectedChatAccount()
     {
+        // Log startup diagnostics for troubleshooting initialization order issues
+        LogTwitchAccountDiagnostics("RefreshSelectedChatAccount");
+
+        // Scenario 1: TwAcc matches main user (or is empty and main exists)
         if (Settings.TwitchUser != null &&
             (string.Equals(Settings.TwAcc, Settings.TwitchUser.Login, StringComparison.OrdinalIgnoreCase) ||
              string.IsNullOrEmpty(Settings.TwAcc)))
@@ -626,10 +658,15 @@ public static class TwitchHandler
                 Token = Settings.TwOAuth
             };
             if (string.IsNullOrEmpty(Settings.TwAcc))
+            {
                 Settings.TwAcc = Settings.TwitchUser.Login;
+                Logger.Info(LogSource.Twitch, $"RefreshSelectedChatAccount: TwAcc was empty, auto-populated with main user '{Settings.TwitchUser.Login}'");
+            }
+            Logger.Info(LogSource.Twitch, $"RefreshSelectedChatAccount: Selected main user '{Settings.TwitchUser.Login}' for chat");
             return true;
         }
 
+        // Scenario 2: TwAcc matches bot user explicitly
         if (Settings.TwitchBotUser != null &&
             string.Equals(Settings.TwAcc, Settings.TwitchBotUser.Login, StringComparison.OrdinalIgnoreCase))
         {
@@ -640,11 +677,28 @@ public static class TwitchHandler
                 Name = Settings.TwitchBotUser.Login,
                 Token = Settings.TwOAuth
             };
+            Logger.Info(LogSource.Twitch, $"RefreshSelectedChatAccount: Selected bot user '{Settings.TwitchBotUser.Login}' for chat");
             return true;
         }
 
+        // Fallback 1: TwAcc is empty and no explicit match, but bot user exists -> use bot as fallback
+        if (string.IsNullOrEmpty(Settings.TwAcc) && Settings.TwitchBotUser != null)
+        {
+            Settings.TwOAuth = $"oauth:{Settings.TwitchBotToken}";
+            Settings.TwitchChatAccount = new TwitchChatAccount
+            {
+                Id = Settings.TwitchBotUser.Id,
+                Name = Settings.TwitchBotUser.Login,
+                Token = Settings.TwOAuth
+            };
+            Settings.TwAcc = Settings.TwitchBotUser.Login;
+            Logger.Info(LogSource.Twitch, $"RefreshSelectedChatAccount: TwAcc empty, fell back to bot user '{Settings.TwitchBotUser.Login}' for chat");
+            return true;
+        }
+
+        // No valid chat account available
         Settings.TwitchChatAccount = null;
-        Logger.Warning(LogSource.Twitch, $"No matching Twitch chat account found for TwAcc='{Settings.TwAcc}'.");
+        Logger.Warning(LogSource.Twitch, $"RefreshSelectedChatAccount: No matching Twitch chat account. TwAcc='{Settings.TwAcc}', MainUser={Settings.TwitchUser?.Login ?? "null"}, BotUser={Settings.TwitchBotUser?.Login ?? "null"}");
         return false;
     }
 
@@ -2708,9 +2762,22 @@ public static class TwitchHandler
                     // Clear persisted bot account credentials/state
                     Settings.TwitchBotToken = "";
                     Settings.TwitchBotUser = null;
-                    Settings.TwAcc = "";
-                    Settings.TwOAuth = "";
                     Settings.BotAccessTokenExpiryDate = DateTime.MinValue;
+
+                    // Safe TwAcc handling: fallback to main user if available instead of clearing
+                    if (Settings.TwitchUser != null && !string.IsNullOrEmpty(Settings.TwitchUser.Login))
+                    {
+                        Settings.TwAcc = Settings.TwitchUser.Login;
+                        Logger.Info(LogSource.Twitch, $"Bot account reset: TwAcc fell back to main user '{Settings.TwitchUser.Login}'");
+                    }
+                    else
+                    {
+                        Settings.TwAcc = "";
+                        Logger.Info(LogSource.Twitch, "Bot account reset: TwAcc cleared (no main user available)");
+                    }
+
+                    // Clear OAuth token regardless
+                    Settings.TwOAuth = "";
 
                     // Clear runtime objects
                     BotTokenCheck = null;

--- a/Songify Slim/Util/Spotify/SpotifyApiHandler.cs
+++ b/Songify Slim/Util/Spotify/SpotifyApiHandler.cs
@@ -116,7 +116,7 @@ namespace Songify_Slim.Util.Spotify
             }
             catch (Exception ex)
             {
-                Logger.Log(LogLevel.Debug, LogSource.Spotify, "Cancel PKCE watchdog failed", ex);
+                Logger.Debug(LogSource.Spotify, "Cancel PKCE watchdog failed", ex);
             }
         }
 
@@ -128,7 +128,7 @@ namespace Songify_Slim.Util.Spotify
             }
             catch (Exception ex)
             {
-                Logger.Log(LogLevel.Debug, LogSource.Spotify, "Cancel PKCE watchdog (restart) failed", ex);
+                Logger.Debug(LogSource.Spotify, "Cancel PKCE watchdog (restart) failed", ex);
             }
 
             try
@@ -137,7 +137,7 @@ namespace Songify_Slim.Util.Spotify
             }
             catch (Exception ex)
             {
-                Logger.Log(LogLevel.Debug, LogSource.Spotify, "Dispose PKCE watchdog CTS failed", ex);
+                Logger.Debug(LogSource.Spotify, "Dispose PKCE watchdog CTS failed", ex);
             }
 
             _pkceLoginWatchdogCts = new CancellationTokenSource();
@@ -181,7 +181,7 @@ namespace Songify_Slim.Util.Spotify
                     }
                     catch (Exception ex)
                     {
-                        Logger.Log(LogLevel.Error, LogSource.Spotify, "Unable to stop auth server", ex);
+                        Logger.Error(LogSource.Spotify, "Unable to stop auth server", ex);
                     }
 
                     _server.AuthorizationCodeReceived -= OnAuthorizationCodeReceived;
@@ -205,7 +205,7 @@ namespace Songify_Slim.Util.Spotify
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log(LogLevel.Error, LogSource.Spotify,
+                    Logger.Error(LogSource.Spotify,
                         "OAuth callback server could not start on port 4002.", ex);
 
                     string ownerSummary = GetPortOwnerSummary(4002);
@@ -286,7 +286,7 @@ namespace Songify_Slim.Util.Spotify
                 }
                 catch (InvalidOperationException ex)
                 {
-                    Logger.Log(LogLevel.Debug, LogSource.Spotify,
+                    Logger.Debug(LogSource.Spotify,
                         $"IPv6 loopback probe failed for port {port}; continuing with IPv4-only OAuth callback.", ex);
                 }
             }
@@ -337,7 +337,7 @@ namespace Songify_Slim.Util.Spotify
             }
             catch (Exception ex)
             {
-                Logger.Log(LogLevel.Debug, LogSource.Spotify, "Failed to resolve port owner information", ex);
+                Logger.Debug(LogSource.Spotify, "Failed to resolve port owner information", ex);
                 return "Owning process could not be resolved.";
             }
         }
@@ -569,7 +569,7 @@ namespace Songify_Slim.Util.Spotify
             }
             catch (APIException ex)
             {
-                Logger.Log(LogLevel.Error, LogSource.Spotify,
+                Logger.Error(LogSource.Spotify,
                     "Spotify token refresh failed (API). " + ApiCallMeter.FormatApiExceptionDetails(ex));
                 SpotifyUserNotifier.Notify(
                     "Spotify session refresh failed",
@@ -580,7 +580,7 @@ namespace Songify_Slim.Util.Spotify
             }
             catch (Exception ex)
             {
-                Logger.Log(LogLevel.Error, LogSource.Spotify, "Spotify token refresh failed.", ex);
+                Logger.Error(LogSource.Spotify, "Spotify token refresh failed.", ex);
                 string msg = ex.Message;
                 if (msg.Length > 200)
                     msg = msg.Substring(0, 197) + "...";
@@ -611,7 +611,7 @@ namespace Songify_Slim.Util.Spotify
         {
             try
             {
-                Logger.Log(LogLevel.Debug, LogSource.Spotify, "Entered OnAuthorizationCodeReceived");
+                Logger.Debug(LogSource.Spotify, "Entered OnAuthorizationCodeReceived");
 
                 if (response == null)
                     throw new Exception("AuthorizationCodeResponse was null.");
@@ -624,7 +624,7 @@ namespace Songify_Slim.Util.Spotify
 
                 OAuthClient oauth = new();
 
-                Logger.Log(LogLevel.Debug, LogSource.Spotify, "Sending PKCE token request");
+                Logger.Debug(LogSource.Spotify, "Sending PKCE token request");
 
                 PKCETokenResponse tokenResponse;
                 try
@@ -640,7 +640,7 @@ namespace Songify_Slim.Util.Spotify
                 }
                 catch (APIException ex)
                 {
-                    Logger.Log(LogLevel.Error, LogSource.Spotify,
+                    Logger.Error(LogSource.Spotify,
                         "PKCE token exchange failed. " + ApiCallMeter.FormatApiExceptionDetails(ex));
                     SpotifyUserNotifier.Notify(
                         "Spotify login incomplete",
@@ -996,22 +996,82 @@ namespace Songify_Slim.Util.Spotify
             try
             {
                 using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
+                string configuredDeviceId = Settings.SpotifyDeviceId;
+                DeviceResponse devicesResponse = await ApiCallMeter.RunAsync(
+                    "Player.GetAvailableDevices",
+                    () => Client.Player.GetAvailableDevices(cts.Token),
+                    SoftLimitPerminute,
+                    cts.Token);
+
+                List<Device> devices = devicesResponse?.Devices?.Where(d => d != null).ToList() ?? new List<Device>();
+                Device matchedDevice = devices.FirstOrDefault(d => string.Equals(d.Id, configuredDeviceId, StringComparison.Ordinal));
+                Device activeDevice = devices.FirstOrDefault(d => d.IsActive);
+
+                Logger.Debug(
+                    LogSource.Spotify,
+                    $"Queue device detection: configuredDeviceId='{configuredDeviceId}', deviceCount={devices.Count}, matchedConfigured={(matchedDevice != null)}, activeDeviceId='{activeDevice?.Id}'");
+
+                if (devices.Count > 0)
+                {
+                    Logger.Debug(LogSource.Spotify, $"Queue device candidates: {FormatSpotifyDeviceList(devices)}");
+                }
+
+                // If the configured device is not in the current device list, fall back to the active device.
+                string requestDeviceId = configuredDeviceId;
+                if (matchedDevice == null && activeDevice != null)
+                {
+                    Logger.Warning(LogSource.Spotify,
+                        $"Configured deviceId '{configuredDeviceId}' not found in available devices. " +
+                        $"Falling back to active device '{activeDevice.Id}' ('{activeDevice.Name}'). " +
+                        "Updating stored device id.");
+                    requestDeviceId = activeDevice.Id;
+                    Settings.SpotifyDeviceId = activeDevice.Id;
+                }
+                else if (matchedDevice == null && activeDevice == null)
+                {
+                    Logger.Warning(LogSource.Spotify,
+                        $"Configured deviceId '{configuredDeviceId}' not found and no active device detected. " +
+                        "Player.AddToQueue will likely fail with 404 Device not found. " +
+                        "Ensure Spotify is open and playing on a device.");
+                }
+
+                Logger.Info(
+                    LogSource.Spotify,
+                    $"Queue device selected for Player.AddToQueue: requestDeviceId='{requestDeviceId}', selectedDeviceName='{matchedDevice?.Name ?? activeDevice?.Name ?? "Unknown"}', songUri='{songUri}'");
+
                 await ApiCallMeter.RunAsync("Player.AddToQueue", () => Client.Player.AddToQueue(
                     new PlayerAddToQueueRequest(songUri)
                     {
-                        DeviceId = Settings.SpotifyDeviceId
+                        DeviceId = requestDeviceId
                     }, cts.Token), softLimitPerMinute: SoftLimitPerminute, ct: cts.Token);
                 return true;
             }
             catch (APIException ex)
             {
-                Logger.Log(LogLevel.Error, LogSource.Spotify, "Error Adding song to queue", ex);
-                if (ex.Response == null || (int)ex.Response.StatusCode != 503) return false;
+                Logger.Error(LogSource.Spotify, "Error Adding song to queue", ex);
+
+                int statusCode = ex.Response != null ? (int)ex.Response.StatusCode : 0;
+
+                // 404 = no active/found device. Clear the stale device id so next playback tick re-detects it.
+                if (statusCode == 404)
+                {
+                    Logger.Warning(LogSource.Spotify,
+                        $"Player.AddToQueue received 404 Device not found for deviceId='{Settings.SpotifyDeviceId}'. " +
+                        "Clearing stored device id so it will be re-detected on next playback update. " +
+                        "Ensure Spotify is open and active on a device before requesting songs.");
+                    Settings.SpotifyDeviceId = string.Empty;
+                    return false;
+                }
+
+                if (statusCode != 503) return false;
                 for (int i = 0; i < 5; i++)
                 {
                     await Task.Delay(1000);
                     try
                     {
+                        Logger.Info(
+                            LogSource.Spotify,
+                            $"Retrying Player.AddToQueue after 503 (attempt {i + 1}/5) with deviceId='{Settings.SpotifyDeviceId}' and songUri='{songUri}'");
                         await ApiCallMeter.RunAsync("Player.AddToQueue", () => Client.Player.AddToQueue(
                             new PlayerAddToQueueRequest(songUri)
                             {
@@ -1212,7 +1272,7 @@ namespace Songify_Slim.Util.Spotify
 
                     List<string> uris = EnsureTrackUris([trackId]);
 
-                    Logger.Log(LogLevel.Info, LogSource.Spotify,
+                    Logger.Info(LogSource.Spotify,
                         $"Library.SaveItems URIs: {string.Join(", ", uris)}");
 
                     //bool response = await ApiCallMeter.RunAsync(
@@ -1249,7 +1309,7 @@ namespace Songify_Slim.Util.Spotify
                 }
                 catch (Exception cacheEx)
                 {
-                    Logger.Log(LogLevel.Warning, LogSource.Spotify,
+                    Logger.Warning(LogSource.Spotify,
                         "EnsurePlaylistCacheAsync failed, falling back to raw playlist fetch", cacheEx);
                 }
             }
@@ -1495,7 +1555,7 @@ namespace Songify_Slim.Util.Spotify
             }
             catch (OperationCanceledException)
             {
-                Logger.Log(LogLevel.Warning, LogSource.Spotify, "Spotify GetUser was cancelled.");
+                Logger.Warning(LogSource.Spotify, "Spotify GetUser was cancelled.");
                 return null;
             }
             catch (Exception ex)
@@ -1534,7 +1594,16 @@ namespace Songify_Slim.Util.Spotify
 
                 DeviceResponse x = await ApiCallMeter.RunAsync("Player.GetAvailableDevices",
                     () => Client.Player.GetAvailableDevices(cts.Token), SoftLimitPerminute, cts.Token);
-                return x.Devices.FirstOrDefault(d => d.IsActive)?.Name;
+
+                List<Device> devices = x?.Devices?.Where(d => d != null).ToList() ?? new List<Device>();
+                Device matchedDevice = devices.FirstOrDefault(d => string.Equals(d.Id, spotifyDeviceId, StringComparison.Ordinal));
+                Device activeDevice = devices.FirstOrDefault(d => d.IsActive);
+
+                Logger.Info(
+                    LogSource.Spotify,
+                    $"Device lookup: requestedDeviceId='{spotifyDeviceId}', deviceCount={devices.Count}, matchedConfigured={(matchedDevice != null)}, activeDeviceId='{activeDevice?.Id}'");
+
+                return matchedDevice?.Name ?? activeDevice?.Name;
             }
             catch (Exception e)
             {
@@ -1652,6 +1721,20 @@ namespace Songify_Slim.Util.Spotify
 
             int idx = s.LastIndexOf(separator);
             return (idx >= 0 && idx < s.Length - 1) ? s.Substring(idx + 1) : s;
+        }
+
+        private static string FormatSpotifyDeviceList(IEnumerable<Device> devices)
+        {
+            if (devices == null)
+                return "[]";
+
+            List<string> formatted = devices
+                .Where(d => d != null)
+                .Select(d =>
+                    $"{{id='{d.Id}', name='{d.Name}', type='{d.Type}', active={d.IsActive}, restricted={d.IsRestricted}}}")
+                .ToList();
+
+            return formatted.Count == 0 ? "[]" : string.Join(", ", formatted);
         }
 
         public static async Task SetShuffle(bool b)
@@ -1891,7 +1974,7 @@ namespace Songify_Slim.Util.Spotify
             }
             catch (Exception e)
             {
-                Logger.Log(LogLevel.Error, LogSource.Spotify, "Error checking if IDs are already in Library.", e);
+                Logger.Error(LogSource.Spotify, "Error checking if IDs are already in Library.", e);
                 return null;
             }
         }

--- a/Songify Slim/Views/MainWindow.xaml.cs
+++ b/Songify Slim/Views/MainWindow.xaml.cs
@@ -1650,13 +1650,13 @@ namespace Songify_Slim.Views
             ServiceIndicatorState indicatorState = GetPearIndicatorState();
 
             string action = indicatorState.IsConnecting
-                ? "Connection in progress"
+                ? "Click indicator to stop and pause auto-connect"
                 : indicatorState.IsConnected
                     ? "Click indicator to disconnect"
                     : Settings.Player == PlayerType.Pear && PearWebSocketClient.AutoConnectEnabled
-                        ? "Click indicator to connect"
+                        ? "Click indicator to pause auto-connect"
                         : Settings.Player == PlayerType.Pear
-                            ? "Pear auto-connect paused"
+                            ? "Click indicator to resume auto-connect"
                         : "Click indicator to switch to Pear and connect";
 
             return indicatorState.BuildRows(
@@ -2322,7 +2322,12 @@ namespace Songify_Slim.Views
 
                 case "PearDesktop":
                     if (PearWebSocketClient.IsConnecting)
+                    {
+                        PearWebSocketClient.AutoConnectEnabled = false;
+                        await Sf.NotifyPearPlayerInactiveAsync();
+                        UpdatePearStatusIndicator();
                         break;
+                    }
 
                     if (PearWebSocketClient.IsConnected)
                     {
@@ -2331,17 +2336,30 @@ namespace Songify_Slim.Views
                     }
                     else
                     {
-                        PearWebSocketClient.AutoConnectEnabled = true;
-                        if (Settings.Player != PlayerType.Pear)
-                            CbxSource.SelectedValue = PlayerType.Pear;
-
-                        try
+                        if (Settings.Player == PlayerType.Pear)
                         {
-                            await Sf.FetchPear();
+                            if (PearWebSocketClient.AutoConnectEnabled)
+                            {
+                                PearWebSocketClient.AutoConnectEnabled = false;
+                                await Sf.NotifyPearPlayerInactiveAsync();
+                            }
+                            else
+                            {
+                                PearWebSocketClient.AutoConnectEnabled = true;
+                                try
+                                {
+                                    await Sf.FetchPear();
+                                }
+                                catch (Exception ex)
+                                {
+                                    Logger.LogExc(ex);
+                                }
+                            }
                         }
-                        catch (Exception ex)
+                        else
                         {
-                            Logger.LogExc(ex);
+                            PearWebSocketClient.AutoConnectEnabled = true;
+                            CbxSource.SelectedValue = PlayerType.Pear;
                         }
                     }
 

--- a/Songify Slim/Views/MainWindow.xaml.cs
+++ b/Songify Slim/Views/MainWindow.xaml.cs
@@ -1354,11 +1354,6 @@ namespace Songify_Slim.Views
         {
             if (Settings.AutoStartWebServer) GlobalObjects.WebServer.StartWebServer(Settings.WebServerPort);
             if (Settings.OpenQueueOnStartup) OpenQueue();
-            if (Settings.TwAutoConnect)
-            {
-                TwitchHandler.ConnectTwitchChatClient();
-            }
-
             if (Settings.AutoClearQueue)
             {
                 GlobalObjects.ReqList.Clear();
@@ -1370,10 +1365,25 @@ namespace Songify_Slim.Views
                 await SongifyApi.ClearQueueAsync(Json.Serialize(payload));
             }
 
+            // If the tokens exist we should initiatilize them first and then connect the chat client if auto connect is enabled.
+            Logger.Debug(LogSource.Twitch, "HandleTwitchInitializationAsync: Account init starting");
             if (!string.IsNullOrWhiteSpace(Settings.TwitchAccessToken))
+            {
+                Logger.Debug(LogSource.Twitch, "HandleTwitchInitializationAsync: Initializing Main account");
                 await TwitchHandler.InitializeApi(Enums.TwitchAccount.Main);
+            }
             if (!string.IsNullOrWhiteSpace(Settings.TwitchBotToken))
+            {
+                Logger.Debug(LogSource.Twitch, "HandleTwitchInitializationAsync: Initializing Bot account");
                 await TwitchHandler.InitializeApi(Enums.TwitchAccount.Bot);
+            }
+
+            Logger.Debug(LogSource.Twitch, "HandleTwitchInitializationAsync: Account init complete");
+            if (Settings.TwAutoConnect)
+            {
+                Logger.Debug(LogSource.Twitch, "HandleTwitchInitializationAsync: Auto-connecting chat");
+                TwitchHandler.ConnectTwitchChatClient();
+            }
         }
 
         private static void CheckAndNotifyConfigurationIssues()
@@ -1761,7 +1771,6 @@ namespace Songify_Slim.Views
             {
                 _timerFetcher.Enabled = false;
                 _timerFetcher.Elapsed -= OnTimedEvent;
-                CancellationTokenSource _sCts = new CancellationTokenSource();
                 Stopwatch fetchLoopStart = _selectedSource == PlayerType.WindowsPlayback ? Stopwatch.StartNew() : null;
 
                 try
@@ -1795,7 +1804,6 @@ namespace Songify_Slim.Views
 
                 try
                 {
-                    _sCts.CancelAfter(3500);
                     await GetCurrentSongAsync();
                     if (fetchLoopStart != null)
                     {
@@ -1840,7 +1848,6 @@ namespace Songify_Slim.Views
                             throw new ArgumentOutOfRangeException();
                     }
 
-                    _sCts.Dispose();
                     _timerFetcher.Enabled = enable;
                     _timerFetcher.Elapsed += OnTimedEvent;
                 }


### PR DESCRIPTION
making Twitch/Spotify startup and recovery more resilient, giving clearer Pear connection controls, and adding higher-signal diagnostics so failures are faster to understand and fix