### PR TITLE
Bugfix/twitch init spotify device recovery

### DIFF
--- a/Songify Slim/Util/Songify/SongFetcher.cs
+++ b/Songify Slim/Util/Songify/SongFetcher.cs
@@ -86,7 +86,12 @@ namespace Songify_Slim.Util.Songify
 
         private bool _pearWsHandlerRegistered;
         private bool _pearColdHttpSynced;
-        private DateTimeOffset _pearWsConnectFailureNotifiedAt;
+        /// <summary>True after the first connection failure; prevents further toasts until a successful connect resets this.</summary>
+        private bool _pearWsConnectFailureNotified;
+        /// <summary>Consecutive failed connection attempts since the last successful connect or manual disconnect.</summary>
+        private int _pearWsConnectFailureCount;
+        /// <summary>Earliest time at which <see cref="FetchPear"/> will attempt the next WebSocket connect.</summary>
+        private DateTimeOffset _pearWsNextConnectAttemptAt;
 
         // Pear/YT Music quirk: now-playing VideoId can differ from the queued item's Id.
         // Track the Pear queue's current item id so we can correlate requests reliably.
@@ -1430,9 +1435,13 @@ namespace Songify_Slim.Util.Songify
             await GlobalObjects.WebServer.BroadcastToChannelAsync("/ws/data", updatedJson);
         }
 
-        public async Task FetchPear()
+        public async Task FetchPear(bool forceNow = false)
         {
             if (!PearWebSocketClient.AutoConnectEnabled)
+                return;
+
+            // Respect exponential backoff for automatic checks; explicit user checks can bypass it.
+            if (!forceNow && DateTimeOffset.UtcNow < _pearWsNextConnectAttemptAt)
                 return;
 
             await EnsurePearWebSocketAsync().ConfigureAwait(false);
@@ -1457,8 +1466,22 @@ namespace Songify_Slim.Util.Songify
             _pearColdHttpSynced = false;
             _pearWsHandlerRegistered = false;
             _lastPearQueueCurrentId = null;
+            ResetPearConnectionState();
             PearWebSocketClient.SetMessageHandler(null);
             await PearWebSocketClient.DisconnectAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Returns the remaining backoff before the next automatic Pear connect attempt.
+        /// <c>null</c> means no backoff is currently active.
+        /// </summary>
+        public TimeSpan? GetPearConnectBackoffRemaining()
+        {
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            if (_pearWsNextConnectAttemptAt <= now)
+                return null;
+
+            return _pearWsNextConnectAttemptAt - now;
         }
 
         private async Task EnsurePearWebSocketAsync()
@@ -1472,12 +1495,14 @@ namespace Songify_Slim.Util.Songify
             try
             {
                 await PearWebSocketClient.ConnectAsync().ConfigureAwait(false);
-                // Clear the failure notification state on successful connect.
-                _pearWsConnectFailureNotifiedAt = default;
+                // Successful connect — reset all failure/backoff state so the next failure cycle starts fresh.
+                ResetPearConnectionState();
             }
             catch (Exception ex)
             {
                 Logger.Error(LogSource.Pear, "Pear WebSocket could not connect.", ex);
+                _pearWsConnectFailureCount++;
+                _pearWsNextConnectAttemptAt = DateTimeOffset.UtcNow + GetPearConnectBackoffDelay(_pearWsConnectFailureCount);
                 NotifyPearConnectionFailure(ex);
                 return;
             }
@@ -1488,13 +1513,12 @@ namespace Songify_Slim.Util.Songify
 
         private void NotifyPearConnectionFailure(Exception ex)
         {
-            // Throttle: show at most one toast per 2 minutes for repeated connection failures.
-            TimeSpan throttleWindow = TimeSpan.FromMinutes(2);
-            DateTimeOffset now = DateTimeOffset.UtcNow;
-            if (now - _pearWsConnectFailureNotifiedAt < throttleWindow)
+            // Only notify once per failure run; subsequent attempts fail silently.
+            // ResetPearConnectionState() re-arms this when a connect succeeds.
+            if (_pearWsConnectFailureNotified)
                 return;
 
-            _pearWsConnectFailureNotifiedAt = now;
+            _pearWsConnectFailureNotified = true;
 
             string detail = ex?.Message ?? "Unknown error";
             if (detail.Length > 160)
@@ -1503,8 +1527,21 @@ namespace Songify_Slim.Util.Songify
             SpotifyUserNotifier.Notify(
                 "Pear (YouTube Music) not available",
                 $"Could not connect to the Pear WebSocket at {PearWebSocketClient.Endpoint}.\n{detail}\nMake sure Pear is running.",
-                "pear:ws:connect_failed",
-                throttleWindow);
+                "pear:ws:connect_failed");
+        }
+
+        private void ResetPearConnectionState()
+        {
+            _pearWsConnectFailureNotified = false;
+            _pearWsConnectFailureCount = 0;
+            _pearWsNextConnectAttemptAt = default;
+        }
+
+        /// <summary>5 s base, doubles per failure, capped at 5 minutes.</summary>
+        private static TimeSpan GetPearConnectBackoffDelay(int failureCount)
+        {
+            double seconds = Math.Min(5.0 * Math.Pow(2.0, failureCount - 1), 300.0);
+            return TimeSpan.FromSeconds(seconds);
         }
 
         /// <summary>

--- a/Songify Slim/Util/Songify/Twitch/TwitchHandler.cs
+++ b/Songify Slim/Util/Songify/Twitch/TwitchHandler.cs
@@ -4148,10 +4148,14 @@ public static class TwitchHandler
 
     private static bool IsInQueue(string id)
     {
-        // Checks if the song ID is already in the internal queue (Mainwindow reqList)
-        List<RequestObject> temp = GlobalObjects.ReqList.Where(x => x.Trackid == id).ToList();
+        // Treat now-playing as in-queue so the same song cannot be requested while playing.
+        if (GlobalObjects.CurrentSong != null && GlobalObjects.CurrentSong.SongId == id)
+        {
+            return true;
+        }
 
-        return temp.Count > 0;
+        // Check if the song ID is already in the internal request queue.
+        return GlobalObjects.ReqList.Any(x => x.Trackid == id);
     }
 
     private static Task<(bool IsBlacklisted, string Response)> IsSongBlacklisted(string trackId)

--- a/Songify Slim/Util/Spotify/SpotifyApiHandler.cs
+++ b/Songify Slim/Util/Spotify/SpotifyApiHandler.cs
@@ -997,47 +997,48 @@ namespace Songify_Slim.Util.Spotify
             {
                 using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
                 string configuredDeviceId = Settings.SpotifyDeviceId;
-                DeviceResponse devicesResponse = await ApiCallMeter.RunAsync(
-                    "Player.GetAvailableDevices",
-                    () => Client.Player.GetAvailableDevices(cts.Token),
-                    SoftLimitPerminute,
-                    cts.Token);
 
-                List<Device> devices = devicesResponse?.Devices?.Where(d => d != null).ToList() ?? new List<Device>();
-                Device matchedDevice = devices.FirstOrDefault(d => string.Equals(d.Id, configuredDeviceId, StringComparison.Ordinal));
-                Device activeDevice = devices.FirstOrDefault(d => d.IsActive);
-
-                Logger.Debug(
-                    LogSource.Spotify,
-                    $"Queue device detection: configuredDeviceId='{configuredDeviceId}', deviceCount={devices.Count}, matchedConfigured={(matchedDevice != null)}, activeDeviceId='{activeDevice?.Id}'");
-
-                if (devices.Count > 0)
-                {
-                    Logger.Debug(LogSource.Spotify, $"Queue device candidates: {FormatSpotifyDeviceList(devices)}");
-                }
-
-                // If the configured device is not in the current device list, fall back to the active device.
+                // Only query available devices when no device id has been stored yet.
+                // GetSongInfo updates Settings.SpotifyDeviceId on every playback tick, so
+                // the stored id is authoritative once any playback has been detected.
                 string requestDeviceId = configuredDeviceId;
-                if (matchedDevice == null && activeDevice != null)
+                if (string.IsNullOrWhiteSpace(configuredDeviceId))
                 {
-                    Logger.Warning(LogSource.Spotify,
-                        $"Configured deviceId '{configuredDeviceId}' not found in available devices. " +
-                        $"Falling back to active device '{activeDevice.Id}' ('{activeDevice.Name}'). " +
-                        "Updating stored device id.");
-                    requestDeviceId = activeDevice.Id;
-                    Settings.SpotifyDeviceId = activeDevice.Id;
-                }
-                else if (matchedDevice == null && activeDevice == null)
-                {
-                    Logger.Warning(LogSource.Spotify,
-                        $"Configured deviceId '{configuredDeviceId}' not found and no active device detected. " +
-                        "Player.AddToQueue will likely fail with 404 Device not found. " +
-                        "Ensure Spotify is open and playing on a device.");
+                    DeviceResponse devicesResponse = await ApiCallMeter.RunAsync(
+                        "Player.GetAvailableDevices",
+                        () => Client.Player.GetAvailableDevices(cts.Token),
+                        SoftLimitPerminute,
+                        cts.Token);
+
+                    List<Device> devices = devicesResponse?.Devices?.Where(d => d != null).ToList() ?? new List<Device>();
+                    Device activeDevice = devices.FirstOrDefault(d => d.IsActive);
+
+                    Logger.Debug(
+                        LogSource.Spotify,
+                        $"Queue device detection (no stored id): deviceCount={devices.Count}, activeDeviceId='{activeDevice?.Id}'");
+
+                    if (devices.Count > 0)
+                        Logger.Debug(LogSource.Spotify, $"Queue device candidates: {FormatSpotifyDeviceList(devices)}");
+
+                    if (activeDevice != null)
+                    {
+                        requestDeviceId = activeDevice.Id;
+                        Settings.SpotifyDeviceId = activeDevice.Id;
+                        Logger.Info(LogSource.Spotify,
+                            $"No stored device id. Using active device '{activeDevice.Id}' ('{activeDevice.Name}').");
+                    }
+                    else
+                    {
+                        Logger.Warning(LogSource.Spotify,
+                            "No stored device id and no active device detected. " +
+                            "Player.AddToQueue will likely fail with 404 Device not found. " +
+                            "Ensure Spotify is open and playing on a device.");
+                    }
                 }
 
                 Logger.Info(
                     LogSource.Spotify,
-                    $"Queue device selected for Player.AddToQueue: requestDeviceId='{requestDeviceId}', selectedDeviceName='{matchedDevice?.Name ?? activeDevice?.Name ?? "Unknown"}', songUri='{songUri}'");
+                    $"Queue device selected for Player.AddToQueue: requestDeviceId='{requestDeviceId}', songUri='{songUri}'");
 
                 await ApiCallMeter.RunAsync("Player.AddToQueue", () => Client.Player.AddToQueue(
                     new PlayerAddToQueueRequest(songUri)

--- a/Songify Slim/Views/MainWindow.xaml.cs
+++ b/Songify Slim/Views/MainWindow.xaml.cs
@@ -1648,15 +1648,16 @@ namespace Songify_Slim.Views
         private List<(string Label, string Value)> BuildPearStatusRows()
         {
             ServiceIndicatorState indicatorState = GetPearIndicatorState();
+            TimeSpan? backoffRemaining = Sf.GetPearConnectBackoffRemaining();
 
             string action = indicatorState.IsConnecting
-                ? "Click indicator to stop and pause auto-connect"
+                ? "Connecting"
                 : indicatorState.IsConnected
                     ? "Click indicator to disconnect"
-                    : Settings.Player == PlayerType.Pear && PearWebSocketClient.AutoConnectEnabled
-                        ? "Click indicator to pause auto-connect"
+                    : Settings.Player == PlayerType.Pear && backoffRemaining is { } remaining
+                        ? $"Auto-retry in {Math.Ceiling(remaining.TotalSeconds)}s (backoff active). Click indicator to force check now"
                         : Settings.Player == PlayerType.Pear
-                            ? "Click indicator to resume auto-connect"
+                            ? "Click indicator to reconnect"
                         : "Click indicator to switch to Pear and connect";
 
             return indicatorState.BuildRows(
@@ -2321,45 +2322,28 @@ namespace Songify_Slim.Views
                     break;
 
                 case "PearDesktop":
-                    if (PearWebSocketClient.IsConnecting)
+                    if (Settings.Player != PlayerType.Pear)
                     {
-                        PearWebSocketClient.AutoConnectEnabled = false;
-                        await Sf.NotifyPearPlayerInactiveAsync();
-                        UpdatePearStatusIndicator();
+                        // Switch to Pear; the player-switch handler sets AutoConnectEnabled = true.
+                        CbxSource.SelectedValue = PlayerType.Pear;
                         break;
                     }
 
-                    if (PearWebSocketClient.IsConnected)
+                    if (PearWebSocketClient.IsConnecting || PearWebSocketClient.IsConnected)
                     {
-                        PearWebSocketClient.AutoConnectEnabled = false;
+                        // Disconnect; auto-connect will reconnect on the next fetch cycle.
                         await Sf.NotifyPearPlayerInactiveAsync();
                     }
                     else
                     {
-                        if (Settings.Player == PlayerType.Pear)
+                        // Already disconnected — trigger an immediate connect attempt.
+                        try
                         {
-                            if (PearWebSocketClient.AutoConnectEnabled)
-                            {
-                                PearWebSocketClient.AutoConnectEnabled = false;
-                                await Sf.NotifyPearPlayerInactiveAsync();
-                            }
-                            else
-                            {
-                                PearWebSocketClient.AutoConnectEnabled = true;
-                                try
-                                {
-                                    await Sf.FetchPear();
-                                }
-                                catch (Exception ex)
-                                {
-                                    Logger.LogExc(ex);
-                                }
-                            }
+                            await Sf.FetchPear(forceNow: true);
                         }
-                        else
+                        catch (Exception ex)
                         {
-                            PearWebSocketClient.AutoConnectEnabled = true;
-                            CbxSource.SelectedValue = PlayerType.Pear;
+                            Logger.LogExc(ex);
                         }
                     }
 


### PR DESCRIPTION
fix(twitch-requests): block duplicate requests for currently playing song
fix(pear): keep autoconnect active with one-shot alerts and backoff retries
fix(spotify,queue): skip device lookup when a stored Spotify device id exists
feat(logger,pear): centralize JSON parse exception logging with around-error preview