### PR TITLE
refactor(twitch): normalize request input at ingress and tighten Spotify track URL parsing

### DIFF
--- a/Songify Slim/Util/Songify/Twitch/TwitchHandler.cs
+++ b/Songify Slim/Util/Songify/Twitch/TwitchHandler.cs
@@ -1196,7 +1196,7 @@ public static class TwitchHandler
         if (input.StartsWith("https://open.spotify.com/"))
         {
             // Extract the ID using regular expressions
-            Match match = Regex.Match(input, @"/track/([^/?]+)");
+            Match match = Regex.Match(input, @"/track/([A-Za-z0-9]{22})(?:[/?]|$)");
 
             if (match.Success)
             {
@@ -1225,6 +1225,8 @@ public static class TwitchHandler
     public static async Task HandleBitsSongRequest(string userId, string userName,
         string userInput, string channel)
     {
+        userInput = NormalizeRequestInput(userInput);
+
         TwitchUser existingUser = GlobalObjects.TwitchUsers.FirstOrDefault(o => o.UserId == userId);
 
         int subtier = int.Parse(GlobalObjects.Subscribers.Where(s => s.UserId == userId)
@@ -1315,9 +1317,11 @@ public static class TwitchHandler
         }
     }
 
-    public static async Task HandleChannelPointSongRequst(bool isBroadcaster, string userId, string userName,
+    public static async Task HandleChannelPointSongRequest(bool isBroadcaster, string userId, string userName,
         string userInput, string channel, string rewardId, string redemptionId)
     {
+        userInput = NormalizeRequestInput(userInput);
+
         if (GlobalObjects.TwitchUsers.Count == 0)
         {
             await RunTwitchUserSync();
@@ -2341,7 +2345,7 @@ public static class TwitchHandler
         }
 
         string requestInput = message.Message.Text.Contains(' ')
-            ? message.Message.Text.Substring(message.Message.Text.IndexOf(' ') + 1).Trim()
+            ? NormalizeRequestInput(message.Message.Text.Substring(message.Message.Text.IndexOf(' ') + 1))
             : string.Empty;
 
         if (string.IsNullOrWhiteSpace(requestInput))
@@ -2415,13 +2419,13 @@ public static class TwitchHandler
             case Enums.PlayerType.Spotify:
                 Logger.Info(LogSource.Songrequest,
                     $"[Command] Dispatching request to Spotify handler (user={message.ChatterUserName})");
-                await HandleSpotifyRequest(message, cmdParams, cmd);
+                await HandleSpotifyRequest(message, requestInput, cmdParams, cmd);
                 break;
             //case PlayerType.YtmDesktop:
             case Enums.PlayerType.Pear:
                 Logger.Info(LogSource.Songrequest,
                     $"[Command] Dispatching request to Pear/YouTube handler (user={message.ChatterUserName})");
-                await HandleYtmRequest(message, cmdParams, cmd);
+                await HandleYtmRequest(message, requestInput, cmdParams, cmd);
                 break;
 
             case Enums.PlayerType.WindowsPlayback:
@@ -2663,8 +2667,16 @@ public static class TwitchHandler
         };
     }
 
+    /// <summary>
+    /// Handles chat-based Spotify song requests after command intake has already normalized
+    /// and validated the request text.
+    /// </summary>
+    /// <param name="message">Original Twitch chat message that triggered the command.</param>
+    /// <param name="requestInput">Normalized request text extracted at ingress.</param>
+    /// <param name="cmdParams">Resolved user and command execution context.</param>
+    /// <param name="cmd">The command definition that routed to this handler.</param>
     // ReSharper disable once UnusedParameter.Local
-    private static async Task HandleSpotifyRequest(ChannelChatMessage message, TwitchCommandParams cmdParams, TwitchCommand cmd)
+    private static async Task HandleSpotifyRequest(ChannelChatMessage message, string requestInput, TwitchCommandParams cmdParams, TwitchCommand cmd)
     {
         if (SpotifyApiHandler.Client == null)
         {
@@ -2672,27 +2684,27 @@ public static class TwitchHandler
             return;
         }
 
-        string msg = message.Message.Text.Contains(' ')
-            ? message.Message.Text.Substring(message.Message.Text.IndexOf(' ') + 1)
-            : string.Empty;
-
-        string trackId = await GetTrackIdFromInput(msg.Trim());
+        string trackId = await GetTrackIdFromInput(requestInput);
 
         await AddSong(trackId, TwitchRequestUser.FromChatmessage(message), Enums.SongRequestSource.Command, cmdParams.ExistingUser);
     }
 
+    /// <summary>
+    /// Handles chat-based YouTube Music (Pear) song requests using the request text
+    /// that was already normalized at command ingress.
+    /// </summary>
+    /// <param name="message">Original Twitch chat message that triggered the command.</param>
+    /// <param name="requestInput">Normalized request text extracted at ingress.</param>
+    /// <param name="cmdParams">Resolved user and command execution context.</param>
+    /// <param name="cmd">The command definition that routed to this handler.</param>
     // ReSharper disable once UnusedParameter.Local
-    private static async Task HandleYtmRequest(ChannelChatMessage message, TwitchCommandParams cmdParams, TwitchCommand cmd)
+    private static async Task HandleYtmRequest(ChannelChatMessage message, string requestInput, TwitchCommandParams cmdParams, TwitchCommand cmd)
     {
         switch (Settings.Player)
         {
             case Enums.PlayerType.Pear:
                 {
-                    string msg = message.Message.Text.Contains(' ')
-                        ? message.Message.Text.Substring(message.Message.Text.IndexOf(' ') + 1)
-                        : string.Empty;
-
-                    await AddYtSong(msg.Trim(), TwitchRequestUser.FromChatmessage(message), Enums.SongRequestSource.Command, cmdParams.ExistingUser);
+                    await AddYtSong(requestInput, TwitchRequestUser.FromChatmessage(message), Enums.SongRequestSource.Command, cmdParams.ExistingUser);
                     break;
                 }
 
@@ -2737,6 +2749,11 @@ public static class TwitchHandler
         }
 
         return parameters.Aggregate(source, (current, parameter) => current.Replace($"{{{parameter.Key}}}", parameter.Value));
+    }
+
+    private static string NormalizeRequestInput(string input)
+    {
+        return string.IsNullOrWhiteSpace(input) ? string.Empty : input.Trim();
     }
 
     public static void ResetTwitchSetting(Enums.TwitchAccount account)

--- a/Songify Slim/Util/Songify/Twitch/WebSocketHostedService.cs
+++ b/Songify Slim/Util/Songify/Twitch/WebSocketHostedService.cs
@@ -647,7 +647,7 @@ namespace Songify_Slim.Util.Songify.Twitch
                 await TwitchHandler.RunTwitchUserSync();
                 Logger.Info(LogSource.Twitch, $"Redeem: {eventData.Reward.Title} by {eventData.UserName}");
 
-                await TwitchHandler.HandleChannelPointSongRequst(
+                await TwitchHandler.HandleChannelPointSongRequest(
                     isBroadcaster: eventData.UserId == eventData.BroadcasterUserId,
                     userId: eventData.UserId,
                     userName: eventData.UserName,


### PR DESCRIPTION
normalize song request input once via NormalizeRequestInput for chat, bits, and channel point flows pass normalized requestInput into Spotify/YTM handlers instead of re-parsing message text tighten Spotify track URL regex to match valid 22-char track IDs only add XML docs clarifying normalized request input contract for request handlers