### PR TITLE
build(config): add Cloud Agent dev environment setup

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "Songify",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent setup for Songify.
+#
+# Songify is a Windows-only WPF (.NET Framework 4.8) desktop application, so it
+# cannot be built or run on the Linux Cloud Agent VM. This script prepares the
+# maximum achievable Linux development experience: the .NET SDK toolchain plus a
+# full NuGet restore, which gives the editor/language server the complete
+# dependency graph for navigation, analysis, and editing.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# 1. Ensure the .NET SDK is available (idempotent: apt is a no-op if installed).
+if ! command -v dotnet >/dev/null 2>&1; then
+  echo "Installing .NET SDK 8.0..."
+  sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y dotnet-sdk-8.0
+else
+  echo ".NET SDK already present: $(dotnet --version)"
+fi
+
+# Keep first-run noise and telemetry out of automated setup.
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_NOLOGO=1
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+# 2. Restore NuGet packages so the dependency graph is ready for tooling.
+echo "Restoring NuGet packages..."
+dotnet restore "Songify Slim.sln"
+
+echo "Setup complete. NOTE: building/running Songify requires Windows (WPF/.NET"
+echo "Framework 4.8); the Linux VM supports editing, NuGet restore, and analysis."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cloud Agent development environment for Songify (`.cursor/environment.json` + `.cursor/install.sh`).

Songify is a **Windows-only WPF (.NET Framework 4.8)** desktop application. WPF and the .NET Framework 4.8 targeting pack are Windows-only, and Cloud Agents run on Linux, so the app itself cannot be compiled or run on the Cloud Agent VM. This environment provisions the **maximum achievable Linux development experience**:

- Installs the **.NET SDK 8.0** toolchain (idempotent; `apt` no-op when already present).
- Runs a full **NuGet restore** of `Songify Slim.sln`, producing the complete dependency graph (`obj/project.assets.json`, ~460 KB) so the editor/language server has packages for navigation, analysis, and editing.

The config is committed to the repo (config-as-code), so merging this PR activates it for future Cloud Agents — no dashboard setup required.

## Validation

Verified on this VM and in a fresh Cloud Agent booted from a prebuilt environment build (`bld-20260820-89f8868d`) of the committed config (default image + install script):

| Check | Result |
| --- | --- |
| `.NET SDK 8.0` install (fresh `apt` in build) | Passed (`8.0.130`) |
| `dotnet restore "Songify Slim.sln"` | Passed (dependency graph generated) |
| Install-script idempotence | Passed twice |
| Environment build (default image) | SUCCEEDED |
| Fresh Cloud Agent from build | Passed (SDK 8.0.130, restore assets present, `dotnet restore` exit 0) |

## Known limitation (platform, not configuration)

`dotnet build` fails on Linux as expected: first with `MSB3644` (no net48 reference assemblies), and — even after supplying them — against WPF/Windows-only types (`MahApps.Metro`, `Windows.UI.Composition`, WPF markup compilation). Building and running Songify requires **Windows** (Visual Studio / MSBuild). This is a platform constraint of the app, not something the Linux environment can resolve.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16bf5987-faa9-44d0-9592-394cd8a8d65f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16bf5987-faa9-44d0-9592-394cd8a8d65f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

